### PR TITLE
refactor: update items

### DIFF
--- a/lib/dynamodb/types.ts
+++ b/lib/dynamodb/types.ts
@@ -62,7 +62,6 @@ interface TransactionItems {
 }
 
 interface TransactionWriteDynamoParams {
-  ConditionExpression?: string;
   TableName?: string;
   TransactItems: TransactionItems[];
 }

--- a/lib/dynamodb/types.ts
+++ b/lib/dynamodb/types.ts
@@ -50,11 +50,10 @@ interface ScanDynamoParams {
 }
 
 interface ItemParams {
-  Key: Object;
-  UpdateExpression?: string;
+  Key?: Object;
   ConditionExpression?: string;
+  item?: Object;
   TableName?: string;
-  ExpressionAttributeValues?: Object;
 }
 
 interface TransactionItems {

--- a/lib/dynamodb/types.ts
+++ b/lib/dynamodb/types.ts
@@ -62,6 +62,7 @@ interface TransactionItems {
 }
 
 interface TransactionWriteDynamoParams {
+  ConditionExpression?: string;
   TableName?: string;
   TransactItems: TransactionItems[];
 }

--- a/lib/dynamodb/updateItems.ts
+++ b/lib/dynamodb/updateItems.ts
@@ -7,7 +7,7 @@ import MessageError from './utils/message.errors';
 import generateUpdateQuery from './utils/generate-update-query';
 
 export const updateItems = async (params: TransactionWriteDynamoParams) => {
-  const { TransactItems, TableName } = params;
+  const { TransactItems, TableName, ConditionExpression } = params;
 
   if (!TableName) {
     throw new CloudcarError({
@@ -37,6 +37,7 @@ export const updateItems = async (params: TransactionWriteDynamoParams) => {
       ...updateParams,
       TableName,
     };
+
     if (item) {
       const expression = generateUpdateQuery(item);
       itemToUpdate.Update = {
@@ -44,6 +45,11 @@ export const updateItems = async (params: TransactionWriteDynamoParams) => {
         ...expression,
       };
     }
+
+    if (ConditionExpression) {
+      itemToUpdate.Update.ConditionExpression = ConditionExpression;
+    }
+
     currentBatchToUpdate.TransactItems.push(
       itemToUpdate as DynamoDB.TransactWriteItem,
     );

--- a/tests/unit/libs/dynamodb/updateItems.test.ts
+++ b/tests/unit/libs/dynamodb/updateItems.test.ts
@@ -2,7 +2,10 @@
 import { DynamoDB } from 'aws-sdk';
 import { updateItems } from '../../../../lib/dynamodb/updateItems';
 import { expect, sinon } from '../../../libs.tests/chai.commons';
-import { BatchUpdateDynamoParamsFactory, WrongBatchUpdateDynamoParamsFactory } from '../../../factories/dynamodb.factory';
+import {
+  BatchUpdateDynamoParamsFactory,
+  WrongBatchUpdateDynamoParamsFactory,
+} from '../../../factories/dynamodb.factory';
 import ErrorTypes from '../../../../lib/errors/errorTypes';
 import MessageError from '../../../../lib/dynamodb/utils/message.errors';
 
@@ -23,7 +26,7 @@ describe('AWS-WRAPPER: updateItems', () => {
   it('[SUCCESS] should update the items', async () => {
     const updateDynamoParams = BatchUpdateDynamoParamsFactory();
     dynamoDBTransactWrite.returns({
-      promise: () => { },
+      promise: () => {},
     });
     await updateItems(updateDynamoParams);
     expect(dynamoDBTransactWrite).to.have.been.calledOnce;
@@ -52,9 +55,7 @@ describe('AWS-WRAPPER: updateItems', () => {
       throw new Error('should have throw an error');
     } catch (error) {
       expect(error.name).to.equal(MessageError.updateItems.name);
-      expect(error.message).to.equal(
-        MessageError.updateItems.messages.update,
-      );
+      expect(error.message).to.equal(MessageError.updateItems.messages.update);
       expect(error.type).to.equal(ErrorTypes.FATAL);
     }
   });


### PR DESCRIPTION
## What?

se hace refactor al transactionWrite del update.

## Why?

para poder recibir objetos de la misma forma que un update normal, aparte de recibir updates con las expresiones predefinidas.
