### PR TITLE
feat: add client metadata

### DIFF
--- a/lib/cognito/authenticateWithCustomFlow.ts
+++ b/lib/cognito/authenticateWithCustomFlow.ts
@@ -44,6 +44,9 @@ export const authenticateWithCustomFlow = async (params: AuthParams) => {
         USERNAME: username,
         ANSWER: Answer,
       },
+      ClientMetadata: {
+        Answer,
+      },
     };
     const session = await cognitoClient
       .respondToAuthChallenge(responseChallenge)


### PR DESCRIPTION
## What?

se agrega el  `answer` como metadata al responseToChallenge

## Why?

para que el `preTokenGeneration` pueda acceder a valores
