### PR TITLE
feat: add optional username attribute input

### DIFF
--- a/lib/cognito/createUser.ts
+++ b/lib/cognito/createUser.ts
@@ -40,7 +40,7 @@ export const createUser = async (params: CreateCognitoUser) => {
 
   const data: CognitoIdentityServiceProvider.Types.SignUpRequest = {
     Password: user.password ? user.password : (uuidV1() as string),
-    Username: user.name,
+    Username: user.username ? user.username : user.name,
     UserAttributes: userAttributes,
     ClientId: CognitoClientId,
     ClientMetadata: {

--- a/lib/cognito/types.ts
+++ b/lib/cognito/types.ts
@@ -18,6 +18,7 @@ interface User {
   password?: string;
   name: string;
   email: string;
+  username?: string;
   customAttribute?: CustomAttribute[];
 }
 


### PR DESCRIPTION
## What?

se agrega el input username como opcional para el metodo create de cognito.

## Why?

porque un usuario de backoffice tiene username y name. Username utiliza el valor del email para efectos de login, y name para visualizar un nombre en el perfil/navbar. Al crear una concesionaria o un usuario en el flujo de compra no se entregaba username, ya que directamente se usaba username como el atributo name, pero ahora se necesita una distinción.

## How?


## Testing?


## Screenshots


## Anything Else?

