### PR TITLE
refactor: change return type of uploadItem

### DIFF
--- a/lib/s3/uploadItem.ts
+++ b/lib/s3/uploadItem.ts
@@ -13,7 +13,7 @@ const s3Client = process.env.LOCAL
 
 export const uploadItem = async (
   params: S3.PutObjectRequest,
-): Promise<Object> => {
+): Promise<S3.ManagedUpload.SendData> => {
   try {
     const { Bucket, Body } = params;
     if (Bucket === undefined) {


### PR DESCRIPTION
## What?
Se cambia el tipo de retorno de la función uploadItem de S3.

## Why?
Para no tener que declarar el tipo explícitamente en la API.

## How?
Se cambia el tipo de retorno declarado en la función.

