### PR TITLE
refactor: add expresion to filter expression

### DIFF
--- a/lib/dynamodb/listItems.ts
+++ b/lib/dynamodb/listItems.ts
@@ -71,6 +71,7 @@ export const listItems = async (
       ValidOperators.contains,
       ValidOperators.or,
     );
+    filterExpression = optionalAttributesExpression;
   } else if (RequiredAttributes && !_.isEmpty(RequiredAttributes)) {
     requiredAttributesExpression = generateScanExpression(
       RequiredAttributes,


### PR DESCRIPTION
## What?
Se agrega una linea para que cuando se ingresen solamente atributos opcionales, estos sean tomados en cuenta, ya que en ese caso, la expresión de opcionales no se estaba agregando a la expresión general.

## Why?
Para poder hacer queries con solo atributos opcionales sin un atributo required.

## How?
Se agrega la linea para incluir la expresión.

